### PR TITLE
fix: separate dependencies and features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,10 @@ name = "rsurn"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
+pyo3 = "0.17.3"
 fxhash = "0.2.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+
+[features]
+extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
I was getting an error when trying to build the rust project on my laptop. 

`cargo build`

`error: linking with `cc` failed: exit status: 1`

I was able to work around the error by making these changes, however it does not completely solve the issue. If I run the following:

`cargo build --features extension-module`

I get the same error.

So, this is really just a work around and not a fix.