### PR TITLE
macOSとLinuxの両方でビルドが走るようにする

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "libc",
  "memoffset",
  "parking_lot",
- "pyo3-build-config",
+ "pyo3-build-config 0.17.3",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -165,13 +165,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-build-config"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
 name = "pyo3-ffi"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
 dependencies = [
  "libc",
- "pyo3-build-config",
+ "pyo3-build-config 0.17.3",
 ]
 
 [[package]]
@@ -261,6 +271,7 @@ version = "0.3.0"
 dependencies = [
  "fxhash",
  "pyo3",
+ "pyo3-build-config 0.18.1",
  "rand",
  "rand_distr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "rsurn"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 pyo3 = { version = "0.17.3", features = ["extension-module"] }
 fxhash = "0.2.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+
+[build-dependencies]
+pyo3-build-config = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,7 @@ name = "rsurn"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.17.3"
+pyo3 = { version = "0.17.3", features = ["extension-module"] }
 fxhash = "0.2.1"
 rand = "0.8.5"
 rand_distr = "0.4.3"
-
-[features]
-extension-module = ["pyo3/extension-module"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
## 背景
Linuxでビルドが通らない状態になっていた。

以前、macOSでビルドが通らなかった件は修正された( #1 ) が、これの影響で今度は Linux でビルドが通らなくなった模様。

## 対応
Cargo.toml の内容を見直す。

具体的には、 #1 以前の設定に戻した上で https://pyo3.rs/v0.17.3/building_and_distribution.html#macos に従って macOS 用の設定を加える。