### PR TITLE
macOSでのCIの実行にself-hosted-runnerを使う

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - uses: PyO3/maturin-action@v1


### PR DESCRIPTION
close #4 

## WHAT

github-hostedのmacOSのランナーはお高いので，self-hostedに変更した．

